### PR TITLE
Update mongo-go-driver to 1.0 and sort imports

### DIFF
--- a/controllers/notification.go
+++ b/controllers/notification.go
@@ -3,14 +3,16 @@ package controllers
 import (
 	"bytes"
 	"fmt"
-	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"github.com/websentry/websentry/config"
-	"github.com/websentry/websentry/models"
-	"github.com/websentry/websentry/utils"
 	"html/template"
 	"net/http"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/websentry/websentry/config"
+	"github.com/websentry/websentry/models"
+	"github.com/websentry/websentry/utils"
 )
 
 func notificationToggle(sentryId primitive.ObjectID, lasttime time.Time, old string, new string) error {

--- a/controllers/notification.go
+++ b/controllers/notification.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/gin-gonic/gin"
-	"github.com/mongodb/mongo-go-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"github.com/websentry/websentry/config"
 	"github.com/websentry/websentry/models"
 	"github.com/websentry/websentry/utils"

--- a/controllers/response.go
+++ b/controllers/response.go
@@ -1,8 +1,9 @@
 package controllers
 
 import (
-	"github.com/gin-gonic/gin"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
 const(

--- a/controllers/sentry.go
+++ b/controllers/sentry.go
@@ -3,16 +3,18 @@ package controllers
 import (
 	"bytes"
 	"fmt"
-	"github.com/disintegration/imaging"
-	"github.com/gin-gonic/gin"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-	"github.com/websentry/websentry/models"
-	"github.com/websentry/websentry/utils"
 	"io/ioutil"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/disintegration/imaging"
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/websentry/websentry/models"
+	"github.com/websentry/websentry/utils"
 )
 
 // [url] the url of the page that needs screenshot

--- a/controllers/sentry.go
+++ b/controllers/sentry.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"github.com/disintegration/imaging"
 	"github.com/gin-gonic/gin"
-	"github.com/mongodb/mongo-go-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"github.com/websentry/websentry/models"
 	"github.com/websentry/websentry/utils"
 	"io/ioutil"

--- a/controllers/slave.go
+++ b/controllers/slave.go
@@ -1,14 +1,16 @@
 package controllers
 
 import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"io/ioutil"
 	"math/rand"
 	"strconv"
 	"sync"
 	"time"
 
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
 	"github.com/gin-gonic/gin"
+
 	"github.com/websentry/websentry/models"
 )
 

--- a/controllers/slave.go
+++ b/controllers/slave.go
@@ -1,7 +1,7 @@
 package controllers
 
 import (
-	"github.com/mongodb/mongo-go-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"io/ioutil"
 	"math/rand"
 	"strconv"

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -1,13 +1,15 @@
 package controllers
 
 import (
+	"math/rand"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+
 	"github.com/websentry/websentry/models"
 	"github.com/websentry/websentry/utils"
-	"math/rand"
-	"time"
 )
 
 const (

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -2,8 +2,8 @@ package controllers
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/mongodb/mongo-go-driver/bson"
-	"github.com/mongodb/mongo-go-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"github.com/websentry/websentry/models"
 	"github.com/websentry/websentry/utils"
 	"math/rand"

--- a/databases/mongodb.go
+++ b/databases/mongodb.go
@@ -2,12 +2,13 @@ package databases
 
 import (
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 
 	"github.com/websentry/websentry/config"
 )
 
 func ConnectToMongoDB(dbConfig config.Mongodb) (*mongo.Database, error) {
-	client, err := mongo.Connect(nil, dbConfig.Url)
+	client, err := mongo.NewClient(options.Client().ApplyURI(dbConfig.Url))
 	if err != nil { return nil, err }
 
 	// test connection

--- a/databases/mongodb.go
+++ b/databases/mongodb.go
@@ -1,7 +1,7 @@
 package databases
 
 import (
-	"github.com/mongodb/mongo-go-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo"
 	"github.com/websentry/websentry/config"
 )
 

--- a/databases/mongodb.go
+++ b/databases/mongodb.go
@@ -2,6 +2,7 @@ package databases
 
 import (
 	"go.mongodb.org/mongo-driver/mongo"
+
 	"github.com/websentry/websentry/config"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
-	github.com/mongodb/mongo-go-driver v0.3.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0 // indirect
@@ -21,6 +20,7 @@ require (
 	github.com/ugorji/go/codec v0.0.0-20190204201341-e444a5086c43 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect
+	go.mongodb.org/mongo-driver v1.0.0
 	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67
 	golang.org/x/net v0.0.0-20190213061140-3a22650c66bd // indirect
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect

--- a/middlewares/Header.go
+++ b/middlewares/Header.go
@@ -2,6 +2,7 @@ package middlewares
 
 import (
 	"github.com/gin-gonic/gin"
+
 	"github.com/websentry/websentry/config"
 )
 

--- a/middlewares/slaveAuth.go
+++ b/middlewares/slaveAuth.go
@@ -2,6 +2,7 @@ package middlewares
 
 import (
 	"github.com/gin-gonic/gin"
+
 	"github.com/websentry/websentry/config"
 	"github.com/websentry/websentry/controllers"
 )

--- a/middlewares/userAuth.go
+++ b/middlewares/userAuth.go
@@ -2,7 +2,7 @@ package middlewares
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/mongodb/mongo-go-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"github.com/websentry/websentry/controllers"
 	"github.com/websentry/websentry/utils"
 )

--- a/middlewares/userAuth.go
+++ b/middlewares/userAuth.go
@@ -3,6 +3,7 @@ package middlewares
 import (
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+
 	"github.com/websentry/websentry/controllers"
 	"github.com/websentry/websentry/utils"
 )

--- a/models/common.go
+++ b/models/common.go
@@ -2,10 +2,11 @@ package models
 
 import (
 	"context"
+	"reflect"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"reflect"
 )
 
 var mongoDB *mongo.Database

--- a/models/common.go
+++ b/models/common.go
@@ -2,9 +2,9 @@ package models
 
 import (
 	"context"
-	"github.com/mongodb/mongo-go-driver/bson"
-	"github.com/mongodb/mongo-go-driver/mongo"
-	"github.com/mongodb/mongo-go-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"reflect"
 )
 

--- a/models/notification.go
+++ b/models/notification.go
@@ -2,8 +2,8 @@ package models
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/mongodb/mongo-go-driver/bson"
-	"github.com/mongodb/mongo-go-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Notification struct {

--- a/models/sentry.go
+++ b/models/sentry.go
@@ -1,10 +1,10 @@
 package models
 
 import (
-	"github.com/mongodb/mongo-go-driver/bson"
-	"github.com/mongodb/mongo-go-driver/bson/primitive"
-	"github.com/mongodb/mongo-go-driver/mongo"
-	"github.com/mongodb/mongo-go-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"time"
 )
 

--- a/models/sentry.go
+++ b/models/sentry.go
@@ -1,11 +1,12 @@
 package models
 
 import (
+	"time"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-	"time"
 )
 
 type SentryImage struct {

--- a/models/user.go
+++ b/models/user.go
@@ -2,9 +2,9 @@ package models
 
 import (
 	"errors"
-	"github.com/mongodb/mongo-go-driver/bson"
-	"github.com/mongodb/mongo-go-driver/bson/primitive"
-	"github.com/mongodb/mongo-go-driver/mongo"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/crypto/bcrypt"
 	"time"
 )

--- a/models/user.go
+++ b/models/user.go
@@ -42,7 +42,7 @@ func CheckUserExistence(dn int, u string) (bool, error) {
 		return false, errors.New("wrong parameter: databases does not exist")
 	}
 
-	count, err := c.Count(nil, bson.M{"email": u})
+	count, err := c.CountDocuments(nil, bson.M{"email": u})
 
 	if err != nil {
 		return false, errors.New("failed to count")

--- a/models/user.go
+++ b/models/user.go
@@ -2,11 +2,12 @@ package models
 
 import (
 	"errors"
+	"time"
+
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/crypto/bcrypt"
-	"time"
 )
 
 const (

--- a/server/router.go
+++ b/server/router.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/gin-gonic/gin"
+
 	"github.com/websentry/websentry/controllers"
 	"github.com/websentry/websentry/middlewares"
 )

--- a/server/server.go
+++ b/server/server.go
@@ -1,12 +1,14 @@
 package server
 
 import (
+	"log"
+
 	"github.com/gin-gonic/gin"
+
 	"github.com/websentry/websentry/config"
 	"github.com/websentry/websentry/controllers"
 	"github.com/websentry/websentry/databases"
 	"github.com/websentry/websentry/models"
-	"log"
 )
 
 func Init() {

--- a/utils/email.go
+++ b/utils/email.go
@@ -3,12 +3,14 @@ package utils
 import (
 	"bytes"
 	"fmt"
-	"github.com/websentry/websentry/config"
-	"gopkg.in/gomail.v2"
 	"html/template"
 	"strings"
 	"time"
-	)
+
+	"gopkg.in/gomail.v2"
+
+	"github.com/websentry/websentry/config"
+)
 
 const (
 	chBuffer = 100

--- a/utils/image.go
+++ b/utils/image.go
@@ -2,8 +2,6 @@ package utils
 
 import (
 	"errors"
-	"github.com/disintegration/imaging"
-	"github.com/websentry/websentry/config"
 	"image"
 	"image/png"
 	"math"
@@ -11,6 +9,10 @@ import (
 	"os"
 	"path"
 	"strings"
+
+	"github.com/disintegration/imaging"
+
+	"github.com/websentry/websentry/config"
 )
 
 const imageFilenameChar = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"

--- a/utils/limitAttempts.go
+++ b/utils/limitAttempts.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"github.com/patrickmn/go-cache"
 	"sync"
 	"time"
+
+	"github.com/patrickmn/go-cache"
 )
 
 const (

--- a/utils/token.go
+++ b/utils/token.go
@@ -1,10 +1,12 @@
 package utils
 
 import (
+	"time"
+
 	"github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
+
 	"github.com/websentry/websentry/config"
-	"time"
 )
 
 const (


### PR DESCRIPTION
This PR is for #8 

The settings for sorting imports is:
Sorting type: gofmt

- [x]  Group stdlib imports
- [x]  Move all stdlib imports in a single group
- [x]  Group current project imports